### PR TITLE
check for kms, skip etag check

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -38,7 +38,7 @@ import logging.config
 from boto.compat import urlparse
 from boto.exception import InvalidUriError
 
-__version__ = '2.36.0+dd.3'
+__version__ = '2.36.0+dd.4'
 Version = __version__  # for backware compatibility
 
 # http://bugs.python.org/issue7980

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -976,7 +976,11 @@ class Key(object):
             # object.
             server_side_encryption_customer_algorithm = response.getheader(
                 'x-amz-server-side-encryption-customer-algorithm', None)
-            if server_side_encryption_customer_algorithm is None:
+            # check for kms header, their ETag also doesn't match.
+            server_side_encryption = response.getheader(
+                'x-amz-server-side-encryption', None)
+            if (server_side_encryption_customer_algorithm is None and
+                    server_side_encryption is None):
                 if self.etag != '"%s"' % md5:
                     raise provider.storage_data_error(
                         'ETag from S3 did not match computed MD5. '


### PR DESCRIPTION
Per 
https://github.com/boto/boto/issues/2921
https://github.com/boto/boto/issues/3750

in dogweb, in a govcloud region, boto throws this error:
```
  File "/opt/dogweb/lib/python2.7/site-packages/dd/dfs/providers/boto_bucket.py", line 194, in upload_file
    key.set_contents_from_filename(filename)
  File "/opt/dogweb/lib/python2.7/site-packages/boto/s3/key.py", line 1362, in set_contents_from_filename
    encrypt_key=encrypt_key)
  File "/opt/dogweb/lib/python2.7/site-packages/boto/s3/key.py", line 1293, in set_contents_from_file
    chunked_transfer=chunked_transfer, size=size)
  File "/opt/dogweb/lib/python2.7/site-packages/boto/s3/key.py", line 750, in send_file
    chunked_transfer=chunked_transfer, size=size)
  File "/opt/dogweb/lib/python2.7/site-packages/boto/s3/key.py", line 951, in _send_file_internal
    query_args=query_args
  File "/opt/dogweb/lib/python2.7/site-packages/boto/s3/connection.py", line 664, in make_request
    retry_handler=retry_handler
  File "/opt/dogweb/lib/python2.7/site-packages/boto/connection.py", line 1073, in make_request
    retry_handler=retry_handler)
  File "/opt/dogweb/lib/python2.7/site-packages/boto/connection.py", line 942, in _mexe
    request.body, request.headers)
  File "/opt/dogweb/lib/python2.7/site-packages/boto/s3/key.py", line 882, in sender
    if not self.should_retry(response, chunked_transfer):
  File "/opt/dogweb/lib/python2.7/site-packages/boto/s3/key.py", line 983, in should_retry
    '%s vs. %s' % (self.etag, self.md5))
boto.exception.S3DataError: BotoClientError: ETag from S3 did not match computed MD5. "729db7dc03453dead7df4d825a3e1d4a" vs. 28dc83a1dd88a9a1830b1e3d7159b0df
```